### PR TITLE
Add: Add new tool "Intermittent Fasting Calculator" to miscguide.md

### DIFF
--- a/docs/miscguide.md
+++ b/docs/miscguide.md
@@ -569,7 +569,7 @@
 * [oshaction](https://www.oshaction.org/resources/) - Occupational Health and Safety Resources
 * [CancerFactFinder](https://cancerfactfinder.org/) - Cancer Fact Search
 * [INCIDecoder](https://incidecoder.com/) or [Skin Signal](https://skinsignal.com/) - Skincare Ingredient Lists
-
+* [Intermittent Fasting Calculator](https://intermittentfastingcalculator.org/) - Plan your next meal and fasting window
 ***
 
 ## ▷ Workout / Exercise


### PR DESCRIPTION
Added a new tool called [Intermittent Fasting Calculator](https://intermittentfastingcalculator.org/) to the existing list of Physical Health

I have already checked to ensure it's not already in the wiki. And the format and description were kept consistent with the existing style of the list.

--------------

The Intermittent Fasting Calculator is a free, no-registration online tool that helps you plan the next meal and fasting window. 

Choose from popular methods like 16:8, 14:10, or create custom fasting hours. Simply input your preferred eating time and get instant results with a visual 24-hour timeline. 

Export your schedule as text, image, or PDF for easy sharing and reference. Perfect for beginners and experienced fasters alike.


